### PR TITLE
Return optional redis values in scan stream

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,8 +20,14 @@ jobs:
       run: cargo build --verbose
     - name: Build (geospatial)
       run: cargo build --verbose --features geospatial
-    - name: Run tests
+    - name: Run tests (with items)
       run: cargo test --verbose
       env:
         NO_REDIS: 1
+        RUST_TEST_THREADS: 1
+    - name: Run tests (without items)
+      run: cargo test --verbose
+      env:
+        NO_REDIS: 1
+        SAMPLE_COUNT: 0
         RUST_TEST_THREADS: 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,9 +32,11 @@
 //!
 //! Scan command methods of [`Commands`][] return a stream over scanned items.
 //!
-//! The stream returns tuples of an optional connection object and an item.
+//! The stream returns tuples of an optional connection object and an optional item.
 //! When the last item is returned, the optional value becomes `Some`
 //! which holds the connection object passed to the method. Until then, it is `None`.
+//! The item is normally `Some`. It is set to `None` only if no items are found by scan.
+//! In such case, the stream just returns `(Some, None)` and finishes.
 //!
 //! ```rust,no_run
 //! use futures::prelude::*;
@@ -46,11 +48,38 @@
 //!
 //! let f = connect.and_then(|con|{
 //!     con.scan_match("key*")
-//!         .for_each(|(con, item): (_, String)| {
+//!         .for_each(|(con, item): (_, Option<String>)| {
 //!             println!("{:?}", item);
 //!             if con.is_some() {
 //!                 // The last item comes with the connection object.
+//!                 if item.is_none() {
+//!                     // If no items found by scan, `(Some(con), None)` is given.
+//!                     println!("No item");
+//!                 }
 //!             }
+//!             Ok(())
+//!         })
+//! }).map_err(|e| eprintln!("{}", e));
+//!
+//! tokio::run(f);
+//! # }
+//! ```
+//!
+//! If you are interested in only items, `filter_map` can be used to simplify.
+//!
+//! ```rust,no_run
+//! use futures::prelude::*;
+//! use redis_ac::Commands;
+//!
+//! # fn main() {
+//! let client = redis::Client::open("redis://127.0.0.1").unwrap();
+//! let connect = client.get_async_connection();
+//!
+//! let f = connect.and_then(|con|{
+//!     con.scan_match("key*")
+//!         .filter_map(|(_, item)| item)
+//!         .for_each(|item: String| {
+//!             // Here we get only items.
 //!             Ok(())
 //!         })
 //! }).map_err(|e| eprintln!("{}", e));

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -27,7 +27,7 @@ fn scan() {
         let exp = write_values("key");
 
         c.get_async_connection()
-            .and_then(|con| con.scan().map(|(_, v)| v).collect())
+            .and_then(|con| con.scan().filter_map(|(_, v)| v).collect())
             .map(|mut res: Vec<String>| {
                 res.sort();
                 assert_eq!(res, keys(exp))
@@ -42,8 +42,23 @@ fn scan_match() {
         let _ = write_values("garbage");
 
         c.get_async_connection()
-            .and_then(|con| con.scan_match("key:*").map(|(_, v)| v).collect())
+            .and_then(|con| con.scan_match("key:*").filter_map(|(_, v)| v).collect())
             .map(|mut res: Vec<String>| {
+                res.sort();
+                assert_eq!(res, keys(exp))
+            })
+    })
+}
+
+#[test]
+fn scan_match_all() {
+    test(|c| {
+        let exp = write_values("key");
+        let _ = write_values("garbage");
+
+        c.get_async_connection()
+            .and_then(|con| con.scan_match("key:*").all())
+            .map(|(_, mut res): (_, Vec<String>)| {
                 res.sort();
                 assert_eq!(res, keys(exp))
             })
@@ -56,7 +71,14 @@ fn hscan() {
         let exp = write_hash_values("hash", "key");
 
         c.get_async_connection()
-            .and_then(|con| con.hscan("hash").map(|(_, v)| v).collect())
+            .and_then(|con| {
+                con.hscan("hash")
+                    .filter_map(|(c, v)| {
+                        assert!((c.is_some() && v.is_none()) || v.is_some());
+                        v
+                    })
+                    .collect()
+            })
             .map(move |mut res: Vec<(String, String)>| {
                 res.sort();
                 assert_eq!(res, both(exp))
@@ -71,8 +93,30 @@ fn hscan_match() {
         let _ = write_hash_values("hash", "garbage");
 
         c.get_async_connection()
-            .and_then(|con| con.hscan_match("hash", "key:*").map(|(_, v)| v).collect())
+            .and_then(|con| {
+                con.hscan_match("hash", "key:*")
+                    .filter_map(|(c, v)| {
+                        assert!((c.is_some() && v.is_none()) || v.is_some());
+                        v
+                    })
+                    .collect()
+            })
             .map(move |mut res: Vec<(String, String)>| {
+                res.sort();
+                assert_eq!(res, both(exp))
+            })
+    })
+}
+
+#[test]
+fn hscan_match_all() {
+    test(|c| {
+        let exp = write_hash_values("hash", "key");
+        let _ = write_hash_values("hash", "garbage");
+
+        c.get_async_connection()
+            .and_then(|con| con.hscan_match("hash", "key:*").all())
+            .map(move |(_, mut res): (_, Vec<(String, String)>)| {
                 res.sort();
                 assert_eq!(res, both(exp))
             })
@@ -85,7 +129,14 @@ fn sscan() {
         let exp = write_set_values("set", "key");
 
         c.get_async_connection()
-            .and_then(|con| con.sscan("set").map(|(_, v)| v).collect())
+            .and_then(|con| {
+                con.sscan("set")
+                    .filter_map(|(c, v)| {
+                        assert!((c.is_some() && v.is_none()) || v.is_some());
+                        v
+                    })
+                    .collect()
+            })
             .map(move |mut res: Vec<String>| {
                 res.sort();
                 assert_eq!(res, keys(exp));
@@ -100,8 +151,30 @@ fn sscan_match() {
         let _ = write_set_values("set", "garbage");
 
         c.get_async_connection()
-            .and_then(|con| con.sscan_match("set", "key:*").map(|(_, v)| v).collect())
+            .and_then(|con| {
+                con.sscan_match("set", "key:*")
+                    .filter_map(|(c, v)| {
+                        assert!((c.is_some() && v.is_none()) || v.is_some());
+                        v
+                    })
+                    .collect()
+            })
             .map(move |mut res: Vec<String>| {
+                res.sort();
+                assert_eq!(res, keys(exp));
+            })
+    })
+}
+
+#[test]
+fn sscan_match_all() {
+    test(|c| {
+        let exp = write_set_values("set", "key");
+        let _ = write_set_values("set", "garbage");
+
+        c.get_async_connection()
+            .and_then(|con| con.sscan_match("set", "key:*").all())
+            .map(move |(_, mut res): (_, Vec<String>)| {
                 res.sort();
                 assert_eq!(res, keys(exp));
             })
@@ -114,7 +187,14 @@ fn zscan() {
         let exp = write_zset_values("zset", "key");
 
         c.get_async_connection()
-            .and_then(|con| con.zscan("zset").map(|(_, v)| v).collect())
+            .and_then(|con| {
+                con.zscan("zset")
+                    .filter_map(|(c, v)| {
+                        assert!((c.is_some() && v.is_none()) || v.is_some());
+                        v
+                    })
+                    .collect()
+            })
             .map(move |mut res: Vec<(String, String)>| {
                 res.sort();
                 assert_eq!(res, both(exp));
@@ -129,8 +209,30 @@ fn zscan_match() {
         let _ = write_zset_values("zset", "garbage");
 
         c.get_async_connection()
-            .and_then(|con| con.zscan_match("zset", "key:*").map(|(_, v)| v).collect())
+            .and_then(|con| {
+                con.zscan_match("zset", "key:*")
+                    .filter_map(|(c, v)| {
+                        assert!((c.is_some() && v.is_none()) || v.is_some());
+                        v
+                    })
+                    .collect()
+            })
             .map(move |mut res: Vec<(String, String)>| {
+                res.sort();
+                assert_eq!(res, both(exp));
+            })
+    })
+}
+
+#[test]
+fn zscan_match_all() {
+    test(|c| {
+        let exp = write_zset_values("zset", "key");
+        let _ = write_zset_values("zset", "garbage");
+
+        c.get_async_connection()
+            .and_then(|con| con.zscan_match("zset", "key:*").all())
+            .map(move |(_, mut res): (_, Vec<(String, String)>)| {
                 res.sort();
                 assert_eq!(res, both(exp));
             })

--- a/tests/helper.rs
+++ b/tests/helper.rs
@@ -137,8 +137,15 @@ where
     data2
 }
 
+pub fn count() -> usize {
+    std::env::var("SAMPLE_COUNT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(10000)
+}
+
 pub fn write_values(prefix: &str) -> Vec<(String, String)> {
-    let data: Vec<_> = (0..10000)
+    let data: Vec<_> = (0..count())
         .map(|i| (format!("{}:{:06}", prefix, i), format!("value{}", i)))
         .collect();
 
@@ -146,7 +153,7 @@ pub fn write_values(prefix: &str) -> Vec<(String, String)> {
 }
 
 pub fn write_hash_values(set: &str, prefix: &str) -> Vec<(String, String)> {
-    let data: Vec<_> = (0..10000)
+    let data: Vec<_> = (0..count())
         .map(|i| (format!("{}:{:06}", prefix, i), format!("value{}", i)))
         .collect();
 
@@ -155,7 +162,7 @@ pub fn write_hash_values(set: &str, prefix: &str) -> Vec<(String, String)> {
 }
 
 pub fn write_set_values(set: &str, prefix: &str) -> Vec<(String, String)> {
-    let data: Vec<_> = (0..10000)
+    let data: Vec<_> = (0..count())
         .map(|i| (format!("{}:{:06}", prefix, i), "unused".into()))
         .collect();
 
@@ -164,7 +171,7 @@ pub fn write_set_values(set: &str, prefix: &str) -> Vec<(String, String)> {
 }
 
 pub fn write_zset_values(set: &str, prefix: &str) -> Vec<(String, String)> {
-    let data: Vec<_> = (0..10000)
+    let data: Vec<_> = (0..count())
         .map(|i| (format!("{}:{:06}", prefix, i), format!("{}", i)))
         .collect();
 


### PR DESCRIPTION
Previously, scan stream implemented this stream.

`Stream<Item=(Option<Conection>, Value)>`

If no items are found by scan, there wasn't a way to return back connection to users
because the stream immediately returns `Async::Ready(None)` (no chance to return `Async::Ready((Some, _))`). This commit changes the interface like this.

`Stream<Item=(Option<Connection>, Option<Value>)>`

The stream returns `(Some, None)` if no items are found.